### PR TITLE
Update Rekor configuration with new shard and origin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,10 +17,16 @@ Logs:
 # Golang's sum DB:
   - Origin: go.sum database tree
     PublicKey: sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
-# SigStore/Rekor log:
-  - Origin: Rekor
+# Sigstore/Rekor log, first shard:
+  - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
+    ID: 3904496407287907110
+# Sigstore/Rekor log, second shard:
+  - Origin: rekor.sigstore.dev - 2605736670972794746
+    PublicKeyType: ecdsa
+    PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
+    ID: 2605736670972794746
 # This next one is the Pixel BT log, it has a broken Origin currently and will need to be fixed.
   - Origin: DEFAULT
     PublicKeyType: ecdsa

--- a/config.yaml
+++ b/config.yaml
@@ -21,12 +21,10 @@ Logs:
   - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    ID: 3904496407287907110
 # Sigstore/Rekor log, second shard:
   - Origin: rekor.sigstore.dev - 2605736670972794746
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    ID: 2605736670972794746
 # This next one is the Pixel BT log, it has a broken Origin currently and will need to be fixed.
   - Origin: DEFAULT
     PublicKeyType: ecdsa


### PR DESCRIPTION
Rekor is now sharded, so we specify the tree ID in the origin, and each shard has its own key.